### PR TITLE
Use lightweight jwt-decode package instead of jsonwebtoken

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-polyfill": "^6.7.2",
     "lokka": "^1.6.1",
     "lokka-transport-http": "^1.3.2",
-    "jsonwebtoken": "^5.7.0"
+    "jwt-decode": "2.2.x"
   },
   "devDependencies": {
     "nodemon": "1.7.x",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import jwt from 'jsonwebtoken';
+import jwtDecode from 'jwt-decode';
 import HttpTransport from 'lokka-transport-http';
 
 // if the token expires within the next N ms
@@ -113,7 +113,7 @@ export default class Transport {
 
       // assuming the token has an expiration time
       // TODO handle tokens without expiration times
-      const payload = jwt.decode(token);
+      const payload = jwtDecode(token);
       if (!payload || !payload.exp) {
         throw new Error('invalid token');
       }


### PR DESCRIPTION
Problem: `jsonwebtoken` pulls in a LOT of crypto-related packages. And `lokka-transport-jwt-auth` only uses the decoding functionality, so none of the crypto code is ever used.

This PR replaces `jsonwebtoken` with `jwt-decode`, a tiny library from Auth0 themselves, that only does JWT decoding. It has no dependencies.

Making this change reduces my uglified, non-gzipped bundle size by 300 KB.